### PR TITLE
Remove IPython dependency as it is already included in DN

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = ["Franccesco Orozco <franccesco@codingdose.info>"]
 [tool.poetry.dependencies]
 python = "^3.6"
 requests = "^2.25.1"
-ipython = "^7.24.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
This PR removes the redundancy of installing IPython when it is already preinstalled in DN.