### PR TITLE
Fix sending malformed `null` in JSON payload

### DIFF
--- a/dnreporter/dnreporter.py
+++ b/dnreporter/dnreporter.py
@@ -24,7 +24,7 @@ class DNReporter:
             execution_time = self.execution_time()
         req_data = {
             "name": self.report_name,
-            "url": self.project_url,
+            "url": self.project_url if self.project_url else "Not Provided",
             "execution_time": str(execution_time),
             "status": status,
         }


### PR DESCRIPTION
JSON payload contains a `null` value when sending a POST request to the Slack workflow. This workflow doesn't accept the value and returns a 400 error code as it expects a text value. This PR introduces a control flow to send `"Not Provided"` instead of a null value if the `project_url` parameter is not provided.